### PR TITLE
Update max supported date to `2025-12-26`

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1326,7 +1326,7 @@ pub const SPECIAL_DAY_LIST: &[(Ymd, DayKind)] = &[
     (Ymd::new(2024, 10, 6), DayKind::NationalDayHoliday),
     (Ymd::new(2024, 10, 7), DayKind::NationalDayHoliday),
     (Ymd::new(2024, 10, 12), DayKind::NationalDayWorkday),
-    // 2024 年节假日安排
+    // 2025 年节假日安排
     // https://www.gov.cn/zhengce/content/202411/content_6986382.htm
     // 一、元旦：1月1日（周三）放假1天，不调休。
     (Ymd::new(2025, 1, 1), DayKind::NewYearsDayHoliday),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,8 @@ use constants::SPECIAL_DAY_LIST;
 pub fn chinese_holiday<T: Into<Ymd>>(ymd: T) -> DayKind {
     let ymd = ymd.into();
     assert!(
-        ymd >= Ymd::new(2004, 1, 1) && ymd <= Ymd::new(2024, 12, 20),
-        "The library only supports dates from 2004-01-01 to 2024-12-20"
+        ymd >= Ymd::new(2004, 1, 1) && ymd <= Ymd::new(2025, 12, 26),
+        "The library only supports dates from 2004-01-01 to 2025-12-26"
     );
     match SPECIAL_DAY_LIST.binary_search_by_key(&ymd, |(ymd, _)| *ymd) {
         Ok(i) => SPECIAL_DAY_LIST[i].1,
@@ -126,6 +126,7 @@ mod tests {
             (Ymd::new(2004, 12, 31), DayKind::NormalWorkday),
             (Ymd::new(2024, 10, 6), DayKind::NationalDayHoliday),
             (Ymd::new(2024, 12, 20), DayKind::NormalWorkday),
+            (Ymd::new(2025, 10, 11), DayKind::NationalDayWorkday),
         ];
         for c in cases {
             assert_eq!(chinese_holiday(c.0), c.1);


### PR DESCRIPTION
Today is already 2024-12-28, but the maximum supported dates for this library are currently only up to 2024-12-20.